### PR TITLE
fix: 更新初始位置&style

### DIFF
--- a/src/tabs/mobile/tabs.vue
+++ b/src/tabs/mobile/tabs.vue
@@ -232,11 +232,7 @@ export default {
 				viewEl.removeEventListener('touchend', this.handleTouchend, false);
 				this.scrollable = false;
 			}
-			// 当一开始showSetp为true时，右边滚到顶，此时切换showStep为false，需要更新位置
-			const maxOffsetX = this.scrollContentW - this.scrollViewW;
-			if (this.scrollOffset < -maxOffsetX) {
-				this.scrollOffset = -maxOffsetX;
-			}
+			this.scrollable && this.scrollToActive();
 		},
 
 		handleTouchstart(event) {
@@ -354,6 +350,7 @@ export default {
 		position: relative;
 		display: flex;
 		width: fit-content;
+		min-width: 100%;
 	}
 	@include element(item) {
 		position: relative;


### PR DESCRIPTION
**Fixed:**
- **core**: 计算scrollable为true后如果step按钮展示出来，此时滚动容器的宽度将变小，需要重新计算activeItem的位置；
- **style**: 保证nav元素（滚动内容）的最小宽度为滚动容器宽度（min-width: 100%)。